### PR TITLE
add ssl cert exception to check_website

### DIFF
--- a/simple_image_download/simple_image_download.py
+++ b/simple_image_download/simple_image_download.py
@@ -40,7 +40,7 @@ def check_webpage(url):
         request = requests.get(url, allow_redirects=True, timeout=10)
         if 'html' not in str(request.content):
             checked_url = request
-    except ReadTimeout as err:
+    except (ReadTimeout, requests.exceptions.SSLError) as err:
         print(err)
         pass
     return checked_url


### PR DESCRIPTION
Sometimes URL certificate verification fails and the request gets SSLError.
It is better to add this exception in addition to ReadTimeout.